### PR TITLE
Removed "open" to make documentation titles consistent for Axway docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,8 +64,8 @@ id = "UA-56643615-3"
 
 [languages]
 [languages.en]
-title = "Axway Open Documentation"
-description = "Axway Open Documentation"
+title = "Axway Documentation"
+description = "Axway Documentation"
 languageName ="English"
 # Weight used for sorting.
 weight = 1


### PR DESCRIPTION
Thank you for your contribution to the Axway-CLI-Open-Docs repo.

## Describe the changes

The bundle name on the doc portal and Google search results was showing "Axway Open Documentation." Since "open" does not mean anything and to make the bundle titles consistent across Axway docs, renamed the bundle to use "Axway Documentation" instead of "Axway Open Documentation."

